### PR TITLE
Optional initialize and more flexible server handling

### DIFF
--- a/src/SenseNet.Client.Tests/Initializer.cs
+++ b/src/SenseNet.Client.Tests/Initializer.cs
@@ -8,7 +8,7 @@ namespace SenseNet.Client.Tests
         [AssemblyInitialize]
         public static void InitializeAllTests(TestContext context)
         {
-            ClientContext.Initialize(new[]
+            ClientContext.Current.AddServers(new[]
             {
                 new ServerContext
                 {

--- a/src/SenseNet.Client.Tests/LoadContentTests.cs
+++ b/src/SenseNet.Client.Tests/LoadContentTests.cs
@@ -143,7 +143,7 @@ namespace SenseNet.Client.Tests
         [TestMethod]
         public async Task Query_Simple()
         {
-            var tasks = await Content.QueryAsync("+TypeIs:Task",
+            var tasks = await Content.QueryAsync("+TypeIs:Folder",
                 new[] {"Id", "Name", "Path", "DisplayName", "Description"},
                 settings: new QuerySettings
                 {
@@ -159,7 +159,7 @@ namespace SenseNet.Client.Tests
         [TestMethod]
         public async Task Query_Complex()
         {
-            var tasks = await Content.QueryAsync("+TypeIs:(Task Memo) +Description:*ae* +CreationDate:>'2000-01-01'",
+            var tasks = await Content.QueryAsync("+TypeIs:(File Folder) +Name:(*e* *.js) +CreationDate:>'2000-01-01'",
                 new[] { "Id", "Name", "Path", "DisplayName", "Description" },
                 settings: new QuerySettings
                 {

--- a/src/SenseNet.Client.Tests/SenseNet.Client.Tests.csproj
+++ b/src/SenseNet.Client.Tests/SenseNet.Client.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="RenameTests.cs" />
     <Compile Include="EventLoggerTests.cs" />
     <Compile Include="RepositoryPathTests.cs" />
+    <Compile Include="ServerContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SenseNet.Client\SenseNet.Client.csproj">

--- a/src/SenseNet.Client.Tests/ServerContextTests.cs
+++ b/src/SenseNet.Client.Tests/ServerContextTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SenseNet.Client.Tests
+{
+    [TestClass]
+    public class ServerContextTests
+    {
+        [TestMethod]
+        public void AddSingleServer()
+        {
+            var serversToAdd = new[] { new ServerContext { Url = "1" } };
+
+            ManipulateServers(serversToAdd, null, "1");
+        }
+
+        [TestMethod]
+        public void AddMultipleServers()
+        {
+            var ids = Enumerable.Range(0, 10).ToArray();
+            var serversToAdd = ids.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+
+            ManipulateServers(serversToAdd, null, string.Join(";", ids));
+        }
+
+        [TestMethod]
+        public void AddMultipleServers_Parallel()
+        {
+            var ids = Enumerable.Range(0, 500).ToArray();
+            var serversToAdd = ids.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+
+            var cc = new ClientContext();
+
+            Parallel.ForEach(serversToAdd, s => cc.AddServer(s));
+
+            // We have to sort the added servers before comparing to the original list, 
+            // because Parallel.Foreach adds items in a mixed order.
+            var actual = string.Join(";", cc.Servers.Select(s => Convert.ToInt32(s.Url)).OrderBy(sid => sid));
+
+            Assert.AreEqual(string.Join(";", ids), actual);
+        }
+
+        [TestMethod]
+        public void RemoveMultipleServers()
+        {
+            var idsToAdd = Enumerable.Range(0, 10).ToArray();
+            
+            var serversToAdd = idsToAdd.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+            var serversToRemove = serversToAdd.Skip(5).ToArray();
+
+            // remove the last few servers
+            ManipulateServers(serversToAdd, serversToRemove, string.Join(";", idsToAdd.Take(5)));
+            
+            // try to remove servers by id: it should not work
+            var idsToRemove = Enumerable.Range(5, 10).ToArray();
+            serversToRemove = idsToRemove.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+
+            // The expected list is the unmodified, full list, because 
+            // add and remove compares servers as object reference!
+            ManipulateServers(serversToAdd, serversToRemove, string.Join(";", idsToAdd));
+        }
+
+        private static void ManipulateServers(ServerContext[] serversToAdd, ServerContext[] serversToRemove, string expectedList)
+        {
+            var cc = new ClientContext();
+
+            if (serversToAdd != null)
+                cc.AddServers(serversToAdd);
+            if (serversToRemove != null)
+                cc.RemoveServers(serversToRemove);
+
+            var actual = string.Join(";", cc.Servers.Select(s => s.Url));
+
+            Assert.AreEqual(expectedList, actual);
+        }
+    }
+}

--- a/src/SenseNet.Client.Tests/ServerContextTests.cs
+++ b/src/SenseNet.Client.Tests/ServerContextTests.cs
@@ -15,7 +15,21 @@ namespace SenseNet.Client.Tests
 
             ManipulateServers(serversToAdd, null, "1");
         }
+        [TestMethod]
+        public void AddSingleServer_MoreThanOnce()
+        {
+            var server = new ServerContext { Url = "1" };
+            var cc = new ClientContext();
 
+            // add the same server multiple times
+            cc.AddServer(server);
+            cc.AddServer(server);
+            cc.AddServer(server);
+
+            // expectation: added only once
+            Assert.AreEqual(1, cc.Servers.Length);
+            Assert.AreEqual(server, cc.Server);
+        }
         [TestMethod]
         public void AddMultipleServers()
         {
@@ -24,7 +38,6 @@ namespace SenseNet.Client.Tests
 
             ManipulateServers(serversToAdd, null, string.Join(";", ids));
         }
-
         [TestMethod]
         public void AddMultipleServers_Parallel()
         {
@@ -41,7 +54,7 @@ namespace SenseNet.Client.Tests
 
             Assert.AreEqual(string.Join(";", ids), actual);
         }
-
+        
         [TestMethod]
         public void RemoveMultipleServers()
         {
@@ -60,6 +73,68 @@ namespace SenseNet.Client.Tests
             // The expected list is the unmodified, full list, because 
             // add and remove compares servers as object reference!
             ManipulateServers(serversToAdd, serversToRemove, string.Join(";", idsToAdd));
+        }
+        [TestMethod]
+        public void RemoveMultipleServers_Parallel()
+        {
+            var idsToAdd = Enumerable.Range(0, 100).ToArray();
+            var idsToRemain = idsToAdd.Where(i => i % 2 == 1).ToArray();
+            var serversToAdd = idsToAdd.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+
+            // servers with even ids
+            var serversToRemove = serversToAdd.Where(s => Convert.ToInt32(s.Url)%2 == 0).ToArray();
+
+            var cc = new ClientContext();
+
+            cc.AddServers(serversToAdd);
+
+            Parallel.ForEach(serversToRemove, s => cc.RemoveServer(s));
+
+            var actual = string.Join(";", cc.Servers.Select(s => Convert.ToInt32(s.Url)).OrderBy(sid => sid));
+            Assert.AreEqual(string.Join(";", idsToRemain), actual);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void NoServer_Simple()
+        {
+            // ReSharper disable once UnusedVariable
+            var server = new ClientContext().Server;
+        }
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task NoServer_Load()
+        {
+            var savedClientContext = ClientContext.Current;
+
+            try
+            {
+                // create a temporary empty context
+                ClientContext.Current = new ClientContext();
+
+                await Content.LoadAsync(Constants.User.AdminId);
+            }
+            finally
+            {
+                ClientContext.Current = savedClientContext;
+            }
+        }
+
+        [TestMethod]
+        public void RandomServer()
+        {
+            var ids = Enumerable.Range(0, 100).ToArray();
+            var serversToAdd = ids.Select(i => new ServerContext { Url = i.ToString() }).ToArray();
+
+            var cc = new ClientContext();
+            cc.AddServers(serversToAdd);
+
+            var r1 = cc.RandomServer;
+            var r2 = cc.RandomServer;
+            var r3 = cc.RandomServer;
+
+            // Two may be the same (we got extremely lucky), but three? No way.
+            Assert.IsTrue(r1 != r2 || r2 != r3);
         }
 
         private static void ManipulateServers(ServerContext[] serversToAdd, ServerContext[] serversToRemove, string expectedList)

--- a/src/SenseNet.Client/ClientContext.cs
+++ b/src/SenseNet.Client/ClientContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace SenseNet.Client
 {
@@ -18,8 +19,12 @@ namespace SenseNet.Client
         /// A singleton client context instance. Use this for every context-related 
         /// operation (e.g. setting the upload chunk size).
         /// </summary>
-        public static ClientContext Current { get; } = new ClientContext();
+        public static ClientContext Current { get; internal set; } = new ClientContext();
 
+        /// <summary>
+        /// Obsolete method for initializing the client environment. Use the ClientContext.Current property instead.
+        /// </summary>
+        /// <param name="servers"></param>
         [Obsolete("Initializing the client is not necessary anymore. Add servers using the Current singleton property instead.")]
         public static void Initialize(ServerContext[] servers)
         {
@@ -31,19 +36,31 @@ namespace SenseNet.Client
 
         private readonly object _serversLock = new object();
 
+        // Store a thread-local random-generator object to avoid generating the same
+        // random number multiple times but ensure thread safety.
+        // Study material: http://dilbert.com/strip/2001-10-25
+        private static int _randomSeed = Environment.TickCount;
+        private static readonly ThreadLocal<Random> RandomGenerator = new ThreadLocal<Random>(() => 
+            new Random(Interlocked.Increment(ref _randomSeed)));
+
         /// <summary>
         /// The available servers that can be a target of client operations.
         /// </summary>
         public ServerContext[] Servers { get; private set; } = new ServerContext[0];
-
-        public ServerContext MainServer
+        /// <summary>
+        /// Returns the first server from the list (a shortcut for Servers[0]). Throws
+        /// an exception if there are no servers available.
+        /// </summary>
+        public ServerContext Server
         {
             get
             {
-                if (Servers.Length < 1)
+                // store the list in a local variable for thread safety
+                var servers = Servers;
+                if (servers.Length < 1)
                     throw new InvalidOperationException("Please add at least one Server before using the client.");
 
-                return Servers[0];
+                return servers[0];
             }
         }
         /// <summary>
@@ -53,16 +70,25 @@ namespace SenseNet.Client
         {
             get
             {
-                if (Servers.Length == 1)
-                    return MainServer;
-                return Servers[new Random().Next(0, Servers.Length)];
+                // store the list in a local variable for thread safety
+                var servers = Servers;
+                return servers.Length < 2 ? Server : servers[RandomGenerator.Value.Next(0, servers.Length)];
             }
         }
 
+        /// <summary>
+        /// Adds a single server to the servers list. This method is thread safe.
+        /// </summary>
+        /// <param name="server">A server context where the client will send requests.</param>
         public void AddServer(ServerContext server)
         {
             AddServers(new[] { server });
         }
+        /// <summary>
+        /// Adds multiple servers to the servers list. This method is thread safe.
+        /// </summary>
+        /// <param name="servers">A list of server contexts where the client will send requests.</param>
+        /// <exception cref="ArgumentNullException"></exception>
         public void AddServers(IEnumerable<ServerContext> servers)
         {
             if (servers == null)
@@ -78,10 +104,18 @@ namespace SenseNet.Client
                 Servers = serverList.ToArray();
             }
         }
+        /// <summary>
+        /// Removes a server from the servers list. This method is thread safe.
+        /// </summary>
+        /// <param name="server">A server context to remove.</param>
         public void RemoveServer(ServerContext server)
         {
             RemoveServers(new []{ server });
         }
+        /// <summary>
+        /// Removes multiple servers from the servers list. This method is thread safe.
+        /// </summary>
+        /// <param name="servers">A list of server contexts to remove.</param>
         public void RemoveServers(IEnumerable<ServerContext> servers)
         {
             if (servers == null)
@@ -98,14 +132,9 @@ namespace SenseNet.Client
             }
         }
 
-        private int _chunkSizeInBytes = 10485760; // 10 MB
         /// <summary>
         /// Number of bytes sent to the server in one chunk during upload operations. Default: 10 MB.
         /// </summary>
-        public int ChunkSizeInBytes 
-        { 
-            get { return _chunkSizeInBytes; }
-            set { _chunkSizeInBytes = value; }
-        }
+        public int ChunkSizeInBytes { get; set; } = 10485760;
     }
 }

--- a/src/SenseNet.Client/Content.cs
+++ b/src/SenseNet.Client/Content.cs
@@ -74,7 +74,7 @@ namespace SenseNet.Client
         /// <param name="server">Target server. If null, the first one will be used from the configuration.</param>
         protected Content(ServerContext server)
         {
-            Server = server ?? ClientContext.Current.Servers[0];
+            Server = server ?? ClientContext.Current.MainServer;
             _fields = new Dictionary<string, object>();
         }
         /// <summary>

--- a/src/SenseNet.Client/Content.cs
+++ b/src/SenseNet.Client/Content.cs
@@ -74,7 +74,7 @@ namespace SenseNet.Client
         /// <param name="server">Target server. If null, the first one will be used from the configuration.</param>
         protected Content(ServerContext server)
         {
-            Server = server ?? ClientContext.Current.MainServer;
+            Server = server ?? ClientContext.Current.Server;
             _fields = new Dictionary<string, object>();
         }
         /// <summary>

--- a/src/SenseNet.Client/RESTCaller.cs
+++ b/src/SenseNet.Client/RESTCaller.cs
@@ -680,7 +680,7 @@ namespace SenseNet.Client
         private static void SetAuthenticationForRequest(WebRequest myReq, ServerContext server)
         {
             if (server == null)
-                server = ClientContext.Current.Servers[0];
+                server = ClientContext.Current.MainServer;
 
             if (string.IsNullOrEmpty(server.Username))
             {

--- a/src/SenseNet.Client/RESTCaller.cs
+++ b/src/SenseNet.Client/RESTCaller.cs
@@ -680,7 +680,7 @@ namespace SenseNet.Client
         private static void SetAuthenticationForRequest(WebRequest myReq, ServerContext server)
         {
             if (server == null)
-                server = ClientContext.Current.MainServer;
+                server = ClientContext.Current.Server;
 
             if (string.IsNullOrEmpty(server.Username))
             {

--- a/src/SenseNet.Client/ServerContext.cs
+++ b/src/SenseNet.Client/ServerContext.cs
@@ -29,7 +29,7 @@
         public static string GetUrl(ServerContext server)
         {
             if (server == null)
-                server = ClientContext.Current.MainServer;
+                server = ClientContext.Current.Server;
             return server.Url;
         }
     }

--- a/src/SenseNet.Client/ServerContext.cs
+++ b/src/SenseNet.Client/ServerContext.cs
@@ -29,7 +29,7 @@
         public static string GetUrl(ServerContext server)
         {
             if (server == null)
-                server = ClientContext.Current.Servers[0];
+                server = ClientContext.Current.MainServer;
             return server.Url;
         }
     }


### PR DESCRIPTION
- calling **Initialize** at the beginning is **not mandatory anymore**. This makes the client work in environments where we do not have access to a central startup method
- add/remove servers api
- more reliable random server generation
- additional tests for the features above